### PR TITLE
PHP: Unescape slashes 

### DIFF
--- a/php/main.php
+++ b/php/main.php
@@ -46,7 +46,7 @@ function makeDashboard(): string {
 		);
     $json = $builder->build();
 
-	return json_encode($json, JSON_PRETTY_PRINT).PHP_EOL;
+	return json_encode($json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL;
 }
 
 echo makeDashboard();


### PR DESCRIPTION
`Requests / sec` text was printed as `Requests \/ sec` because `json_encode` escape the slashes and it makes invalid json output.